### PR TITLE
Add Firebase API key to deployment workflow

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -13,6 +13,7 @@ permissions:
 env:
   NODE_VERSION: '20'
   FIREBASE_PROJECT_ID: 'nammal-e6351'
+  NEXT_PUBLIC_FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
 
 jobs:
   # Lint and Test Job


### PR DESCRIPTION
This pull request introduces a small update to the Firebase deployment workflow configuration, specifically by adding an environment variable for the Firebase API key.

* The `NEXT_PUBLIC_FIREBASE_API_KEY` environment variable is now set using the secret `FIREBASE_API_KEY` in the `.github/workflows/firebase-deploy.yml` file.